### PR TITLE
Compute pressure for elements

### DIFF
--- a/src/USER-CAC/atom_vec_cac.cpp
+++ b/src/USER-CAC/atom_vec_cac.cpp
@@ -146,6 +146,10 @@ void AtomVecCAC::init()
 
   if (strcmp(comm->comm_style, "cac") != 0)
     error->all(FLERR," cac atom styles require a CAC comm style");
+
+  //Now lets overwrite the default thermo compute with the cac nodal temp one
+  modify->delete_compute("thermo_temp");
+  modify->add_compute("thermo_temp all cac/nodal/temp");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-CAC/fix_cac_box_relax.cpp
+++ b/src/USER-CAC/fix_cac_box_relax.cpp
@@ -1,0 +1,978 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Aidan Thompson (SNL)
+------------------------------------------------------------------------- */
+
+#include "fix_cac_box_relax.h"
+#include <cmath>
+#include <iostream>
+#include <cstring>
+#include <string>
+#include "atom.h"
+#include "domain.h"
+#include "update.h"
+#include "comm.h"
+#include "force.h"
+#include "kspace.h"
+#include "modify.h"
+#include "compute.h"
+#include "error.h"
+#include "math_extra.h"
+#include "fmt/format.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+enum{NONE,XYZ,XY,YZ,XZ};
+enum{ISO,ANISO,TRICLINIC};
+
+#define MAX_LIFO_DEPTH 2     // 3 box0 arrays in *.h dimensioned to this
+
+/* ---------------------------------------------------------------------- */
+
+FixCACBoxRelax::FixCACBoxRelax(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg),
+  id_temp(NULL), id_press(NULL), tflag(0), pflag(0)
+{
+  if (narg < 5) error->all(FLERR,"Illegal fix cac/box/relax command");
+
+  scalar_flag = 1;
+  extscalar = 1;
+  global_freq = 1;
+  no_change_box = 1;
+
+  // default values
+
+  pcouple = NONE;
+  allremap = 1;
+  vmax = 0.0001;
+  deviatoric_flag = 0;
+  nreset_h0 = 0;
+
+  p_target[0] = p_target[1] = p_target[2] =
+    p_target[3] = p_target[4] = p_target[5] = 0.0;
+  p_flag[0] = p_flag[1] = p_flag[2] =
+    p_flag[3] = p_flag[4] = p_flag[5] = 0;
+
+  // turn on tilt factor scaling, whenever applicable
+
+  dimension = domain->dimension;
+
+  scaleyz = scalexz = scalexy = 0;
+  if (domain->yperiodic && domain->xy != 0.0) scalexy = 1;
+  if (domain->zperiodic && dimension == 3) {
+    if (domain->yz != 0.0) scaleyz = 1;
+    if (domain->xz != 0.0) scalexz = 1;
+  }
+
+  // set fixed-point to default = center of cell
+
+  fixedpoint[0] = 0.5*(domain->boxlo[0]+domain->boxhi[0]);
+  fixedpoint[1] = 0.5*(domain->boxlo[1]+domain->boxhi[1]);
+  fixedpoint[2] = 0.5*(domain->boxlo[2]+domain->boxhi[2]);
+
+  // process keywords
+
+  int iarg = 3;
+
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"iso") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      pcouple = XYZ;
+      p_target[0] = p_target[1] = p_target[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[0] = p_flag[1] = p_flag[2] = 1;
+      if (dimension == 2) {
+        p_target[2] = 0.0;
+        p_flag[2] = 0;
+      }
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"aniso") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      pcouple = NONE;
+      p_target[0] = p_target[1] = p_target[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[0] = p_flag[1] = p_flag[2] = 1;
+      if (dimension == 2) {
+        p_target[2] = 0.0;
+        p_flag[2] = 0;
+      }
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"tri") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      pcouple = NONE;
+      scalexy = scalexz = scaleyz = 0;
+      p_target[0] = p_target[1] = p_target[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[0] = p_flag[1] = p_flag[2] = 1;
+      p_target[3] = p_target[4] = p_target[5] = 0.0;
+      p_flag[3] = p_flag[4] = p_flag[5] = 1;
+      if (dimension == 2) {
+        p_target[2] = p_target[3] = p_target[4] = 0.0;
+        p_flag[2] = p_flag[3] = p_flag[4] = 0;
+      }
+      iarg += 2;
+
+    } else if (strcmp(arg[iarg],"x") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[0] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[0] = 1;
+      deviatoric_flag = 1;
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"y") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[1] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[1] = 1;
+      deviatoric_flag = 1;
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"z") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[2] = 1;
+      deviatoric_flag = 1;
+      iarg += 2;
+      if (dimension == 2)
+        error->all(FLERR,"Invalid fix cac/box/relax command for a 2d simulation");
+
+    } else if (strcmp(arg[iarg],"yz") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[3] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[3] = 1;
+      deviatoric_flag = 1;
+      scaleyz = 0;
+      iarg += 2;
+      if (dimension == 2)
+        error->all(FLERR,"Invalid fix cac/box/relax command for a 2d simulation");
+    } else if (strcmp(arg[iarg],"xz") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[4] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[4] = 1;
+      deviatoric_flag = 1;
+      scalexz = 0;
+      iarg += 2;
+      if (dimension == 2)
+        error->all(FLERR,"Invalid fix cac/box/relax command for a 2d simulation");
+    } else if (strcmp(arg[iarg],"xy") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      p_target[5] = force->numeric(FLERR,arg[iarg+1]);
+      p_flag[5] = 1;
+      deviatoric_flag = 1;
+      scalexy = 0;
+      iarg += 2;
+
+    } else if (strcmp(arg[iarg],"couple") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      if (strcmp(arg[iarg+1],"xyz") == 0) pcouple = XYZ;
+      else if (strcmp(arg[iarg+1],"xy") == 0) pcouple = XY;
+      else if (strcmp(arg[iarg+1],"yz") == 0) pcouple = YZ;
+      else if (strcmp(arg[iarg+1],"xz") == 0) pcouple = XZ;
+      else if (strcmp(arg[iarg+1],"none") == 0) pcouple = NONE;
+      else error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+
+    } else if (strcmp(arg[iarg],"dilate") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      if (strcmp(arg[iarg+1],"all") == 0) allremap = 1;
+      else if (strcmp(arg[iarg+1],"partial") == 0) allremap = 0;
+      else error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"vmax") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      vmax = force->numeric(FLERR,arg[iarg+1]);
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"nreset") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      nreset_h0 = force->inumeric(FLERR,arg[iarg+1]);
+      if (nreset_h0 < 0) error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"scalexy") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      if (strcmp(arg[iarg+1],"yes") == 0) scalexy = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) scalexy = 0;
+      else error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"scalexz") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      if (strcmp(arg[iarg+1],"yes") == 0) scalexz = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) scalexz = 0;
+      else error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"scaleyz") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      if (strcmp(arg[iarg+1],"yes") == 0) scaleyz = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) scaleyz = 0;
+      else error->all(FLERR,"Illegal fix cac/box/relax command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"fixedpoint") == 0) {
+      if (iarg+4 > narg) error->all(FLERR,"Illegal fix cac/box/relax command");
+      fixedpoint[0] = force->numeric(FLERR,arg[iarg+1]);
+      fixedpoint[1] = force->numeric(FLERR,arg[iarg+2]);
+      fixedpoint[2] = force->numeric(FLERR,arg[iarg+3]);
+      iarg += 4;
+    } else error->all(FLERR,"Illegal fix cac/box/relax command");
+  }
+
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+  if (p_flag[3]) box_change |= BOX_CHANGE_YZ;
+  if (p_flag[4]) box_change |= BOX_CHANGE_XZ;
+  if (p_flag[5]) box_change |= BOX_CHANGE_XY;
+
+  if (allremap == 0) restart_pbc = 1;
+
+  // error checks
+
+  if (dimension == 2 && (p_flag[2] || p_flag[3] || p_flag[4]))
+    error->all(FLERR,"Invalid fix cac/box/relax command for a 2d simulation");
+  if (dimension == 2 && (pcouple == YZ || pcouple == XZ))
+    error->all(FLERR,"Invalid fix cac/box/relax command for a 2d simulation");
+
+  if (pcouple == XYZ && (p_flag[0] == 0 || p_flag[1] == 0))
+    error->all(FLERR,"Invalid fix cac/box/relax command pressure settings");
+  if (pcouple == XYZ && dimension == 3 && p_flag[2] == 0)
+    error->all(FLERR,"Invalid fix cac/box/relax command pressure settings");
+  if (pcouple == XY && (p_flag[0] == 0 || p_flag[1] == 0))
+    error->all(FLERR,"Invalid fix cac/box/relax command pressure settings");
+  if (pcouple == YZ && (p_flag[1] == 0 || p_flag[2] == 0))
+    error->all(FLERR,"Invalid fix cac/box/relax command pressure settings");
+  if (pcouple == XZ && (p_flag[0] == 0 || p_flag[2] == 0))
+    error->all(FLERR,"Invalid fix cac/box/relax command pressure settings");
+
+  // require periodicity in tensile dimension
+
+  if (p_flag[0] && domain->xperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax on a non-periodic dimension");
+  if (p_flag[1] && domain->yperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax on a non-periodic dimension");
+  if (p_flag[2] && domain->zperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax on a non-periodic dimension");
+
+  // require periodicity in 2nd dim of off-diagonal tilt component
+
+  if (p_flag[3] && domain->zperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix cac/box/relax on a 2nd non-periodic dimension");
+  if (p_flag[4] && domain->zperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix cac/box/relax on a 2nd non-periodic dimension");
+  if (p_flag[5] && domain->yperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix cac/box/relax on a 2nd non-periodic dimension");
+
+  if (scaleyz == 1 && domain->zperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax "
+               "with tilt factor scaling on a 2nd non-periodic dimension");
+  if (scalexz == 1 && domain->zperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax "
+               "with tilt factor scaling on a 2nd non-periodic dimension");
+  if (scalexy == 1 && domain->yperiodic == 0)
+    error->all(FLERR,"Cannot use fix cac/box/relax "
+               "with tilt factor scaling on a 2nd non-periodic dimension");
+
+  if (p_flag[3] && scaleyz == 1)
+    error->all(FLERR,"Cannot use fix cac/box/relax with "
+               "both relaxation and scaling on a tilt factor");
+  if (p_flag[4] && scalexz == 1)
+    error->all(FLERR,"Cannot use fix cac/box/relax with "
+               "both relaxation and scaling on a tilt factor");
+  if (p_flag[5] && scalexy == 1)
+    error->all(FLERR,"Cannot use fix cac/box/relax with "
+               "both relaxation and scaling on a tilt factor");
+
+  if (!domain->triclinic && (p_flag[3] || p_flag[4] || p_flag[5]))
+    error->all(FLERR,"Can not specify Pxy/Pxz/Pyz in "
+               "fix cac/box/relax with non-triclinic box");
+
+  if (pcouple == XYZ && dimension == 3 &&
+      (p_target[0] != p_target[1] || p_target[0] != p_target[2]))
+    error->all(FLERR,"Invalid fix cac/box/relax pressure settings");
+  if (pcouple == XYZ && dimension == 2 && p_target[0] != p_target[1])
+    error->all(FLERR,"Invalid fix cac/box/relax pressure settings");
+  if (pcouple == XY && p_target[0] != p_target[1])
+    error->all(FLERR,"Invalid fix cac/box/relax pressure settings");
+  if (pcouple == YZ && p_target[1] != p_target[2])
+    error->all(FLERR,"Invalid fix cac/box/relax pressure settings");
+  if (pcouple == XZ && p_target[0] != p_target[2])
+    error->all(FLERR,"Invalid fix cac/box/relax pressure settings");
+
+  if (vmax <= 0.0) error->all(FLERR,"Illegal fix cac/box/relax command");
+
+  // pstyle = TRICLINIC if any off-diagonal term is controlled -> 6 dof
+  // else pstyle = ISO if XYZ coupling or XY coupling in 2d -> 1 dof
+  // else pstyle = ANISO -> 3 dof
+
+  if (p_flag[3] || p_flag[4] || p_flag[5]) pstyle = TRICLINIC;
+  else if (pcouple == XYZ || (dimension == 2 && pcouple == XY)) pstyle = ISO;
+  else pstyle = ANISO;
+
+  // create a new compute temp style
+  // id = fix-ID + temp
+  // compute group = all since pressure is always global (group all)
+  //   and thus its KE/temperature contribution should use group all
+
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
+
+  tcmd += " all cac/nodal/temp";
+  modify->add_compute(tcmd);
+  tflag = 1;
+
+  // create a new compute pressure style (virial only)
+  // id = fix-ID + press, compute group = all
+  // pass id_temp as 4th arg to pressure constructor
+
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
+
+  pcmd += " all pressure " + std::string(id_temp) + " virial";
+  modify->add_compute(pcmd);
+  pflag = 1;
+
+  dimension = domain->dimension;
+  nrigid = 0;
+  rfix = 0;
+
+  current_lifo = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixCACBoxRelax::~FixCACBoxRelax()
+{
+  delete [] rfix;
+
+  // delete temperature and pressure if fix created them
+
+  if (tflag) modify->delete_compute(id_temp);
+  if (pflag) modify->delete_compute(id_press);
+  delete [] id_temp;
+  delete [] id_press;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixCACBoxRelax::setmask()
+{
+  int mask = 0;
+  mask |= MIN_ENERGY;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixCACBoxRelax::init()
+{
+  // set temperature and pressure ptrs
+
+  int icompute = modify->find_compute(id_temp);
+  if (icompute < 0)
+    error->all(FLERR,"Temperature ID for fix cac/box/relax does not exist");
+  temperature = modify->compute[icompute];
+
+  icompute = modify->find_compute(id_press);
+  if (icompute < 0)
+    error->all(FLERR,"Pressure ID for fix cac/box/relax does not exist");
+  pressure = modify->compute[icompute];
+
+  pv2e = 1.0 / force->nktv2p;
+
+  if (force->kspace) kspace_flag = 1;
+  else kspace_flag = 0;
+
+  // detect if any rigid fixes exist so rigid bodies move when box is remapped
+  // rfix[] = indices to each fix rigid
+
+  delete [] rfix;
+  nrigid = 0;
+  rfix = NULL;
+
+  for (int i = 0; i < modify->nfix; i++)
+    if (modify->fix[i]->rigid_flag) nrigid++;
+  if (nrigid) {
+    rfix = new int[nrigid];
+    nrigid = 0;
+    for (int i = 0; i < modify->nfix; i++)
+      if (modify->fix[i]->rigid_flag) rfix[nrigid++] = i;
+  }
+
+  // initial box dimensions
+
+  xprdinit = domain->xprd;
+  yprdinit = domain->yprd;
+  zprdinit = domain->zprd;
+  if (dimension == 2) zprdinit = 1.0;
+  vol0 = xprdinit * yprdinit * zprdinit;
+  h0[0] = domain->h[0];
+  h0[1] = domain->h[1];
+  h0[2] = domain->h[2];
+  h0[3] = domain->h[3];
+  h0[4] = domain->h[4];
+  h0[5] = domain->h[5];
+
+  // hydrostatic target pressure and deviatoric target stress
+
+  compute_press_target();
+  if (deviatoric_flag) compute_sigma();
+}
+
+/* ----------------------------------------------------------------------
+   compute energy and force due to extra degrees of freedom
+------------------------------------------------------------------------- */
+
+double FixCACBoxRelax::min_energy(double *fextra)
+{
+  double eng,scale,scalex,scaley,scalez,scalevol;
+
+  temperature->compute_scalar();
+  if (pstyle == ISO) pressure->compute_scalar();
+  else {
+    temperature->compute_vector();
+    pressure->compute_vector();
+  }
+  couple();
+
+  // trigger virial computation on every iteration of minimizer
+
+  pressure->addstep(update->ntimestep+1);
+
+  // compute energy, forces for each extra degree of freedom
+  // returned eng = PV must be in units of energy
+  // returned fextra must likewise be in units of energy
+
+  if (pstyle == ISO) {
+    scale = domain->xprd/xprdinit;
+    if (dimension == 3) {
+      eng = pv2e * p_target[0] * (scale*scale*scale-1.0)*vol0;
+      fextra[0] = pv2e * (p_current[0] - p_target[0])*3.0*scale*scale*vol0;
+    } else {
+      eng = pv2e * p_target[0] * (scale*scale-1.0)*vol0;
+      fextra[0] = pv2e * (p_current[0] - p_target[0])*2.0*scale*vol0;
+    }
+
+  } else {
+    fextra[0] = fextra[1] = fextra[2] = 0.0;
+    scalex = scaley = scalez = 1.0;
+    if (p_flag[0]) scalex = domain->xprd/xprdinit;
+    if (p_flag[1]) scaley = domain->yprd/yprdinit;
+    if (p_flag[2]) scalez = domain->zprd/zprdinit;
+    scalevol = scalex*scaley*scalez;
+    eng = pv2e * p_hydro * (scalevol-1.0)*vol0;
+    if (p_flag[0])
+      fextra[0] = pv2e * (p_current[0] - p_hydro)*scaley*scalez*vol0;
+    if (p_flag[1])
+      fextra[1] = pv2e * (p_current[1] - p_hydro)*scalex*scalez*vol0;
+    if (p_flag[2])
+      fextra[2] = pv2e * (p_current[2] - p_hydro)*scalex*scaley*vol0;
+
+    if (pstyle == TRICLINIC) {
+      fextra[3] = fextra[4] = fextra[5] = 0.0;
+      if (p_flag[3])
+        fextra[3] = pv2e*p_current[3]*scaley*yprdinit*scalex*xprdinit*yprdinit;
+      if (p_flag[4])
+        fextra[4] = pv2e*p_current[4]*scalex*xprdinit*scaley*yprdinit*xprdinit;
+      if (p_flag[5])
+        fextra[5] = pv2e*p_current[5]*scalex*xprdinit*scalez*zprdinit*xprdinit;
+    }
+
+    if (deviatoric_flag) {
+      compute_deviatoric();
+      if (p_flag[0]) fextra[0] -= fdev[0]*xprdinit;
+      if (p_flag[1]) fextra[1] -= fdev[1]*yprdinit;
+      if (p_flag[2]) fextra[2] -= fdev[2]*zprdinit;
+      if (pstyle == TRICLINIC) {
+        if (p_flag[3]) fextra[3] -= fdev[3]*yprdinit;
+        if (p_flag[4]) fextra[4] -= fdev[4]*xprdinit;
+        if (p_flag[5]) fextra[5] -= fdev[5]*xprdinit;
+      }
+
+      eng += compute_strain_energy();
+    }
+  }
+
+  return eng;
+}
+
+/* ----------------------------------------------------------------------
+   store extra dof values for minimization linesearch starting point
+   boxlo0,boxhi0 = box dimensions
+   box values are pushed onto a LIFO stack so nested calls can be made
+   values are popped by calling min_step(0.0)
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::min_store()
+{
+  for (int i = 0; i < 3; i++) {
+    boxlo0[current_lifo][i] = domain->boxlo[i];
+    boxhi0[current_lifo][i] = domain->boxhi[i];
+  }
+  if (pstyle == TRICLINIC) {
+    boxtilt0[current_lifo][0] = domain->yz;
+    boxtilt0[current_lifo][1] = domain->xz;
+    boxtilt0[current_lifo][2] = domain->xy;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   clear the LIFO stack for min_store
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::min_clearstore()
+{
+  current_lifo = 0;
+}
+
+/* ----------------------------------------------------------------------
+   push the LIFO stack for min_store
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::min_pushstore()
+{
+  if (current_lifo >= MAX_LIFO_DEPTH) {
+    error->all(FLERR,"Attempt to push beyond stack limit in fix cac/box/relax");
+    return;
+  }
+  current_lifo++;
+}
+
+
+/* ----------------------------------------------------------------------
+   pop the LIFO stack for min_store
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::min_popstore()
+{
+  if (current_lifo <= 0) {
+    error->all(FLERR,"Attempt to pop empty stack in fix cac/box/relax");
+    return;
+  }
+  current_lifo--;
+}
+
+/* ----------------------------------------------------------------------
+   check if time to reset reference state. If so, do so.
+------------------------------------------------------------------------- */
+
+int FixCACBoxRelax::min_reset_ref()
+{
+  int itmp = 0;
+
+  // if nreset_h0 > 0, reset reference box
+  // every nreset_h0 timesteps
+  // only needed for deviatoric external stress
+
+  if (deviatoric_flag && nreset_h0 > 0) {
+    int delta = update->ntimestep - update->beginstep;
+    if (delta % nreset_h0 == 0) {
+      compute_sigma();
+      itmp = 1;
+    }
+  }
+  return itmp;
+}
+
+/* ----------------------------------------------------------------------
+   change the box dimensions by fraction ds = alpha*hextra
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::min_step(double alpha, double *hextra)
+{
+  if (pstyle == ISO) {
+    ds[0] = ds[1] = ds[2] = alpha*hextra[0];
+  } else {
+    ds[0] = ds[1] = ds[2] = 0.0;
+    if (p_flag[0]) ds[0] = alpha*hextra[0];
+    if (p_flag[1]) ds[1] = alpha*hextra[1];
+    if (p_flag[2]) ds[2] = alpha*hextra[2];
+    if (pstyle == TRICLINIC) {
+      ds[3] = ds[4] = ds[5] = 0.0;
+      if (p_flag[3]) ds[3] = alpha*hextra[3];
+      if (p_flag[4]) ds[4] = alpha*hextra[4];
+      if (p_flag[5]) ds[5] = alpha*hextra[5];
+    }
+  }
+  remap();
+  if (kspace_flag) force->kspace->setup();
+}
+
+/* ----------------------------------------------------------------------
+   max allowed step size along hextra
+------------------------------------------------------------------------- */
+
+double FixCACBoxRelax::max_alpha(double *hextra)
+{
+  double alpha = 1.0;
+  if (pstyle == ISO) alpha = vmax/fabs(hextra[0]);
+  else {
+    if (p_flag[0]) alpha = MIN(alpha,vmax/fabs(hextra[0]));
+    if (p_flag[1]) alpha = MIN(alpha,vmax/fabs(hextra[1]));
+    if (p_flag[2]) alpha = MIN(alpha,vmax/fabs(hextra[2]));
+    if (pstyle == TRICLINIC) {
+      if (p_flag[3]) alpha = MIN(alpha,vmax/fabs(hextra[3]));
+      if (p_flag[4]) alpha = MIN(alpha,vmax/fabs(hextra[4]));
+      if (p_flag[5]) alpha = MIN(alpha,vmax/fabs(hextra[5]));
+    }
+  }
+  return alpha;
+}
+
+/* ----------------------------------------------------------------------
+   return number of degrees of freedom added by this fix
+------------------------------------------------------------------------- */
+
+int FixCACBoxRelax::min_dof()
+{
+  if (pstyle == ISO) return 1;
+  if (pstyle == TRICLINIC) return 6;
+  return 3;
+}
+
+/* ----------------------------------------------------------------------
+   dilate the box and owned/ghost atoms around center of box
+------------------------------------------------------------------------- */
+
+void FixCACBoxRelax::remap()
+{
+  int i,n;
+
+  // rescale simulation box from linesearch starting point
+  // scale atom coords for all atoms or only for fix group atoms
+
+  double ****nodal_positions = atom->nodal_positions; 
+  int *npoly = atom->poly_count;
+  int *nodes_per_element_list = atom->nodes_per_element_list;
+  int *element_type = atom->element_type;
+  int *mask = atom->mask;
+  n = atom->nlocal + atom->nghost;
+
+  // convert pertinent atoms and rigid bodies to lamda coords
+
+  for (i = 0; i < n; i++){
+    for(int ip=0; ip < npoly[i]; ip++){
+      for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+        if (mask[i] & groupbit)
+          domain->x2lamda(nodal_positions[i][ip][in],nodal_positions[i][ip][in]);
+      }
+    }
+  }
+
+  if (nrigid)
+    for (i = 0; i < nrigid; i++)
+      modify->fix[rfix[i]]->deform(0);
+
+  // reset global and local box to new size/shape
+
+  for (i = 0; i < 3; i++)
+    if (p_flag[i]) {
+      double currentBoxLo0 = boxlo0[current_lifo][i];
+      double currentBoxHi0 = boxhi0[current_lifo][i];
+      domain->boxlo[i] = currentBoxLo0 + (currentBoxLo0 - fixedpoint[i])/domain->h[i]*ds[i]*h0[i];
+      domain->boxhi[i] = currentBoxHi0 + (currentBoxHi0 - fixedpoint[i])/domain->h[i]*ds[i]*h0[i];
+      if (domain->boxlo[i] >= domain->boxhi[i])
+        error->all(FLERR,"Fix cac/box/relax generated negative box length");
+    }
+
+  // scale tilt factors with cell, if set
+
+  if (scaleyz) domain->yz = (domain->boxhi[2] - domain->boxlo[2])*h0[3]/h0[2];
+  if (scalexz) domain->xz = (domain->boxhi[2] - domain->boxlo[2])*h0[4]/h0[2];
+  if (scalexy) domain->xy = (domain->boxhi[1] - domain->boxlo[1])*h0[5]/h0[1];
+
+  if (pstyle == TRICLINIC) {
+    if (p_flag[3]) domain->yz = boxtilt0[current_lifo][0]+ds[3]*yprdinit;
+    if (p_flag[4]) domain->xz = boxtilt0[current_lifo][1]+ds[4]*xprdinit;
+    if (p_flag[5]) domain->xy = boxtilt0[current_lifo][2]+ds[5]*xprdinit;
+  }
+
+  domain->set_global_box();
+  domain->set_local_box();
+
+  // convert pertinent atoms and rigid bodies back to box coords
+
+  for (i = 0; i < n; i++){
+    for(int ip=0; ip < npoly[i]; ip++){
+      for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+        if (mask[i] & groupbit)
+          domain->lamda2x(nodal_positions[i][ip][in],nodal_positions[i][ip][in]);
+      }
+    }
+  }
+
+  if (nrigid)
+    for (i = 0; i < nrigid; i++)
+      modify->fix[rfix[i]]->deform(1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixCACBoxRelax::couple()
+{
+  double *tensor = pressure->vector;
+
+  if (pstyle == ISO)
+    p_current[0] = p_current[1] = p_current[2] = pressure->scalar;
+  else if (pcouple == XYZ) {
+    double ave = 1.0/3.0 * (tensor[0] + tensor[1] + tensor[2]);
+    p_current[0] = p_current[1] = p_current[2] = ave;
+  } else if (pcouple == XY) {
+    double ave = 0.5 * (tensor[0] + tensor[1]);
+    p_current[0] = p_current[1] = ave;
+    p_current[2] = tensor[2];
+  } else if (pcouple == YZ) {
+    double ave = 0.5 * (tensor[1] + tensor[2]);
+    p_current[1] = p_current[2] = ave;
+    p_current[0] = tensor[0];
+  } else if (pcouple == XZ) {
+    double ave = 0.5 * (tensor[0] + tensor[2]);
+    p_current[0] = p_current[2] = ave;
+    p_current[1] = tensor[1];
+  } else {
+    p_current[0] = tensor[0];
+    p_current[1] = tensor[1];
+    p_current[2] = tensor[2];
+  }
+
+  // switch order from xy-xz-yz to Voigt
+
+  if (pstyle == TRICLINIC) {
+    p_current[3] = tensor[5];
+    p_current[4] = tensor[4];
+    p_current[5] = tensor[3];
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixCACBoxRelax::modify_param(int narg, char **arg)
+{
+  if (strcmp(arg[0],"temp") == 0) {
+    if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
+    if (tflag) {
+      modify->delete_compute(id_temp);
+      tflag = 0;
+    }
+    delete [] id_temp;
+    int n = strlen(arg[1]) + 1;
+    id_temp = new char[n];
+    strcpy(id_temp,arg[1]);
+
+    int icompute = modify->find_compute(arg[1]);
+    if (icompute < 0)
+      error->all(FLERR,"Could not find fix_modify temperature ID");
+    temperature = modify->compute[icompute];
+
+    if (temperature->tempflag == 0)
+      error->all(FLERR,
+                 "Fix_modify temperature ID does not compute temperature");
+    if (temperature->igroup != 0 && comm->me == 0)
+      error->warning(FLERR,"Temperature for fix modify is not for group all");
+
+    // reset id_temp of pressure to new temperature ID
+
+    icompute = modify->find_compute(id_press);
+    if (icompute < 0)
+      error->all(FLERR,"Pressure ID for fix modify does not exist");
+    modify->compute[icompute]->reset_extra_compute_fix(id_temp);
+
+    return 2;
+
+  } else if (strcmp(arg[0],"press") == 0) {
+    if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
+    if (pflag) {
+      modify->delete_compute(id_press);
+      pflag = 0;
+    }
+    delete [] id_press;
+    int n = strlen(arg[1]) + 1;
+    id_press = new char[n];
+    strcpy(id_press,arg[1]);
+
+    int icompute = modify->find_compute(arg[1]);
+    if (icompute < 0) error->all(FLERR,"Could not find fix_modify pressure ID");
+    pressure = modify->compute[icompute];
+
+    if (pressure->pressflag == 0)
+      error->all(FLERR,"Fix_modify pressure ID does not compute pressure");
+    return 2;
+  }
+  return 0;
+}
+
+/* ----------------------------------------------------------------------
+   compute sigma tensor (needed whenever reference box is reset)
+-----------------------------------------------------------------------*/
+
+void FixCACBoxRelax::compute_sigma()
+{
+  double pdeviatoric[3][3];
+  double tmp1[3][3],sigma_tensor[3][3],h_invtmp[3][3];
+
+  // reset reference box dimensions
+
+  xprdinit = domain->xprd;
+  yprdinit = domain->yprd;
+  zprdinit = domain->zprd;
+  if (dimension == 2) zprdinit = 1.0;
+  vol0 = xprdinit * yprdinit * zprdinit;
+
+  h0_inv[0] = domain->h_inv[0];
+  h0_inv[1] = domain->h_inv[1];
+  h0_inv[2] = domain->h_inv[2];
+  h0_inv[3] = domain->h_inv[3];
+  h0_inv[4] = domain->h_inv[4];
+  h0_inv[5] = domain->h_inv[5];
+
+  h_invtmp[0][0] = h0_inv[0];
+  h_invtmp[1][1] = h0_inv[1];
+  h_invtmp[2][2] = h0_inv[2];
+  h_invtmp[1][2] = h0_inv[3];
+  h_invtmp[0][2] = h0_inv[4];
+  h_invtmp[0][1] = h0_inv[5];
+  h_invtmp[2][1] = 0.0;
+  h_invtmp[2][0] = 0.0;
+  h_invtmp[1][0] = 0.0;
+
+  // compute target deviatoric stress tensor pdevmod
+
+  pdeviatoric[0][0] = pdeviatoric[1][1] = pdeviatoric[2][2] = 0.0;
+  if (p_flag[0]) pdeviatoric[0][0] = p_target[0] - p_hydro;
+  if (p_flag[1]) pdeviatoric[1][1] = p_target[1] - p_hydro;
+  if (p_flag[2]) pdeviatoric[2][2] = p_target[2] - p_hydro;
+  pdeviatoric[1][2] = pdeviatoric[2][1] = p_target[3];
+  pdeviatoric[0][2] = pdeviatoric[2][0] = p_target[4];
+  pdeviatoric[0][1] = pdeviatoric[1][0] = p_target[5];
+
+  // Modify to account for off-diagonal terms
+  // These equations come from the stationarity relation:
+  //    Pdev,sys = Pdev,targ*hinv^t*hdiag
+  // where:
+  // Pdev,sys is the system deviatoric stress tensor,
+  // Pdev,targ = pdeviatoric, effective target deviatoric stress
+  // hinv^t is the transpose of the inverse h tensor
+  // hdiag is the diagonal part of the h tensor
+
+  pdeviatoric[1][1] -= pdeviatoric[1][2]*h0_inv[3]*h0[1];
+  pdeviatoric[0][1] -= pdeviatoric[0][2]*h0_inv[3]*h0[1];
+  pdeviatoric[1][0] = pdeviatoric[0][1];
+  pdeviatoric[0][0] -= pdeviatoric[0][1]*h0_inv[5]*h0[0] +
+    pdeviatoric[0][2]*h0_inv[4]*h0[0];
+
+  // compute symmetric sigma tensor
+
+  MathExtra::times3(h_invtmp,pdeviatoric,tmp1);
+  MathExtra::times3_transpose(tmp1,h_invtmp,sigma_tensor);
+  MathExtra::scalar_times3(vol0,sigma_tensor);
+
+  sigma[0] = sigma_tensor[0][0];
+  sigma[1] = sigma_tensor[1][1];
+  sigma[2] = sigma_tensor[2][2];
+  sigma[3] = sigma_tensor[1][2];
+  sigma[4] = sigma_tensor[0][2];
+  sigma[5] = sigma_tensor[0][1];
+}
+
+/* ----------------------------------------------------------------------
+   compute strain energy
+-----------------------------------------------------------------------*/
+
+double FixCACBoxRelax::compute_strain_energy()
+{
+  // compute strain energy = 0.5*Tr(sigma*h*h^t) in energy units
+
+  double* h = domain->h;
+  double d0,d1,d2;
+
+  if (dimension == 3) {
+    d0 =
+      sigma[0]*(h[0]*h[0]+h[5]*h[5]+h[4]*h[4]) +
+      sigma[5]*(          h[1]*h[5]+h[3]*h[4]) +
+      sigma[4]*(                    h[2]*h[4]);
+    d1 =
+      sigma[5]*(          h[5]*h[1]+h[4]*h[3]) +
+      sigma[1]*(          h[1]*h[1]+h[3]*h[3]) +
+      sigma[3]*(                    h[2]*h[3]);
+    d2 =
+      sigma[4]*(                    h[4]*h[2]) +
+      sigma[3]*(                    h[3]*h[2]) +
+      sigma[2]*(                    h[2]*h[2]);
+  } else {
+    d0 = sigma[0]*(h[0]*h[0]+h[5]*h[5]) + sigma[5]*h[1]*h[5];
+    d1 = sigma[5]*h[5]*h[1] + sigma[1]*h[1]*h[1];
+    d2 = 0.0;
+  }
+
+  double energy = 0.5*(d0+d1+d2)*pv2e;
+  std::cout << energy << "\n";
+  return energy;
+}
+
+/* ----------------------------------------------------------------------
+   compute deviatoric barostat force = h*sigma*h^t
+-----------------------------------------------------------------------*/
+
+void FixCACBoxRelax::compute_deviatoric()
+{
+  double* h = domain->h;
+
+  // [ 0 5 4 ]   [ 0 5 4 ] [ 0 5 4 ]
+  // [ 5 1 3 ] = [ - 1 3 ] [ 5 1 3 ]
+  // [ 4 3 2 ]   [ - - 2 ] [ 4 3 2 ]
+
+  if (dimension == 3) {
+    fdev[0] = pv2e*(h[0]*sigma[0]+h[5]*sigma[5]+h[4]*sigma[4]);
+    fdev[1] = pv2e*(h[1]*sigma[1]+h[3]*sigma[3]);
+    fdev[2] = pv2e*(h[2]*sigma[2]);
+    fdev[3] = pv2e*(h[1]*sigma[3]+h[3]*sigma[2]);
+    fdev[4] = pv2e*(h[0]*sigma[4]+h[5]*sigma[3]+h[4]*sigma[2]);
+    fdev[5] = pv2e*(h[0]*sigma[5]+h[5]*sigma[1]+h[4]*sigma[3]);
+  } else {
+    fdev[0] = pv2e*(h[0]*sigma[0]+h[5]*sigma[5]);
+    fdev[1] = pv2e*(h[1]*sigma[1]);
+    fdev[5] = pv2e*(h[0]*sigma[5]+h[5]*sigma[1]);
+  }
+}
+
+/* ----------------------------------------------------------------------
+   compute hydrostatic target pressure
+-----------------------------------------------------------------------*/
+
+void FixCACBoxRelax::compute_press_target()
+{
+  pflagsum = p_flag[0] + p_flag[1] + p_flag[2];
+
+  p_hydro = 0.0;
+  for (int i = 0; i < 3; i++)
+    if (p_flag[i]) p_hydro += p_target[i];
+  if (pflagsum) p_hydro /= pflagsum;
+
+  for (int i = 0; i < 3; i++) {
+    if (p_flag[i] && fabs(p_hydro - p_target[i]) > 1.0e-6) deviatoric_flag = 1;
+  }
+
+  if (pstyle == TRICLINIC) {
+    for (int i = 3; i < 6; i++)
+      if (p_flag[i] && fabs(p_target[i]) > 1.0e-6) deviatoric_flag = 1;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   compute PV and strain energy for access to the user
+   ---------------------------------------------------------------------- */
+
+double FixCACBoxRelax::compute_scalar()
+{
+  double ftmp[6] = {0.0,0.0,0.0,0.0,0.0,0.0};
+  if (update->ntimestep == 0) return 0.0;
+  return min_energy(ftmp);
+}

--- a/src/USER-CAC/fix_cac_box_relax.cpp
+++ b/src/USER-CAC/fix_cac_box_relax.cpp
@@ -16,11 +16,13 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_cac_box_relax.h"
+#include "fix_cac_minimize.h"
+#include "fix_minimize.h"
 #include <cmath>
-#include <iostream>
 #include <cstring>
 #include <string>
 #include "atom.h"
+#include "min_cac.h"
 #include "domain.h"
 #include "update.h"
 #include "comm.h"
@@ -431,171 +433,170 @@ void FixCACBoxRelax::init()
    compute energy and force due to extra degrees of freedom
 ------------------------------------------------------------------------- */
 
-double FixCACBoxRelax::min_energy(double *fextra)
-{
-  double eng,scale,scalex,scaley,scalez,scalevol;
+    double FixCACBoxRelax::min_energy(double *fextra)
+    {
+      double eng,scale,scalex,scaley,scalez,scalevol;
 
-  temperature->compute_scalar();
-  if (pstyle == ISO) pressure->compute_scalar();
-  else {
-    temperature->compute_vector();
-    pressure->compute_vector();
-  }
-  couple();
-
-  // trigger virial computation on every iteration of minimizer
-
-  pressure->addstep(update->ntimestep+1);
-
-  // compute energy, forces for each extra degree of freedom
-  // returned eng = PV must be in units of energy
-  // returned fextra must likewise be in units of energy
-
-  if (pstyle == ISO) {
-    scale = domain->xprd/xprdinit;
-    if (dimension == 3) {
-      eng = pv2e * p_target[0] * (scale*scale*scale-1.0)*vol0;
-      fextra[0] = pv2e * (p_current[0] - p_target[0])*3.0*scale*scale*vol0;
-    } else {
-      eng = pv2e * p_target[0] * (scale*scale-1.0)*vol0;
-      fextra[0] = pv2e * (p_current[0] - p_target[0])*2.0*scale*vol0;
-    }
-
-  } else {
-    fextra[0] = fextra[1] = fextra[2] = 0.0;
-    scalex = scaley = scalez = 1.0;
-    if (p_flag[0]) scalex = domain->xprd/xprdinit;
-    if (p_flag[1]) scaley = domain->yprd/yprdinit;
-    if (p_flag[2]) scalez = domain->zprd/zprdinit;
-    scalevol = scalex*scaley*scalez;
-    eng = pv2e * p_hydro * (scalevol-1.0)*vol0;
-    if (p_flag[0])
-      fextra[0] = pv2e * (p_current[0] - p_hydro)*scaley*scalez*vol0;
-    if (p_flag[1])
-      fextra[1] = pv2e * (p_current[1] - p_hydro)*scalex*scalez*vol0;
-    if (p_flag[2])
-      fextra[2] = pv2e * (p_current[2] - p_hydro)*scalex*scaley*vol0;
-
-    if (pstyle == TRICLINIC) {
-      fextra[3] = fextra[4] = fextra[5] = 0.0;
-      if (p_flag[3])
-        fextra[3] = pv2e*p_current[3]*scaley*yprdinit*scalex*xprdinit*yprdinit;
-      if (p_flag[4])
-        fextra[4] = pv2e*p_current[4]*scalex*xprdinit*scaley*yprdinit*xprdinit;
-      if (p_flag[5])
-        fextra[5] = pv2e*p_current[5]*scalex*xprdinit*scalez*zprdinit*xprdinit;
-    }
-
-    if (deviatoric_flag) {
-      compute_deviatoric();
-      if (p_flag[0]) fextra[0] -= fdev[0]*xprdinit;
-      if (p_flag[1]) fextra[1] -= fdev[1]*yprdinit;
-      if (p_flag[2]) fextra[2] -= fdev[2]*zprdinit;
-      if (pstyle == TRICLINIC) {
-        if (p_flag[3]) fextra[3] -= fdev[3]*yprdinit;
-        if (p_flag[4]) fextra[4] -= fdev[4]*xprdinit;
-        if (p_flag[5]) fextra[5] -= fdev[5]*xprdinit;
+      temperature->compute_scalar();
+      if (pstyle == ISO) pressure->compute_scalar();
+      else {
+        temperature->compute_vector();
+        pressure->compute_vector();
       }
+      couple();
 
-      eng += compute_strain_energy();
+      // trigger virial computation on every iteration of minimizer
+
+      pressure->addstep(update->ntimestep+1);
+
+      // compute energy, forces for each extra degree of freedom
+      // returned eng = PV must be in units of energy
+      // returned fextra must likewise be in units of energy
+
+      if (pstyle == ISO) {
+        scale = domain->xprd/xprdinit;
+        if (dimension == 3) {
+          eng = pv2e * p_target[0] * (scale*scale*scale-1.0)*vol0;
+          fextra[0] = pv2e * (p_current[0] - p_target[0])*3.0*scale*scale*vol0;
+        } else {
+          eng = pv2e * p_target[0] * (scale*scale-1.0)*vol0;
+          fextra[0] = pv2e * (p_current[0] - p_target[0])*2.0*scale*vol0;
+        }
+
+      } else {
+        fextra[0] = fextra[1] = fextra[2] = 0.0;
+        scalex = scaley = scalez = 1.0;
+        if (p_flag[0]) scalex = domain->xprd/xprdinit;
+        if (p_flag[1]) scaley = domain->yprd/yprdinit;
+        if (p_flag[2]) scalez = domain->zprd/zprdinit;
+        scalevol = scalex*scaley*scalez;
+        eng = pv2e * p_hydro * (scalevol-1.0)*vol0;
+        if (p_flag[0])
+          fextra[0] = pv2e * (p_current[0] - p_hydro)*scaley*scalez*vol0;
+        if (p_flag[1])
+          fextra[1] = pv2e * (p_current[1] - p_hydro)*scalex*scalez*vol0;
+        if (p_flag[2])
+          fextra[2] = pv2e * (p_current[2] - p_hydro)*scalex*scaley*vol0;
+
+        if (pstyle == TRICLINIC) {
+          fextra[3] = fextra[4] = fextra[5] = 0.0;
+          if (p_flag[3])
+            fextra[3] = pv2e*p_current[3]*scaley*yprdinit*scalex*xprdinit*yprdinit;
+          if (p_flag[4])
+            fextra[4] = pv2e*p_current[4]*scalex*xprdinit*scaley*yprdinit*xprdinit;
+          if (p_flag[5])
+            fextra[5] = pv2e*p_current[5]*scalex*xprdinit*scalez*zprdinit*xprdinit;
+        }
+
+        if (deviatoric_flag) {
+          compute_deviatoric();
+          if (p_flag[0]) fextra[0] -= fdev[0]*xprdinit;
+          if (p_flag[1]) fextra[1] -= fdev[1]*yprdinit;
+          if (p_flag[2]) fextra[2] -= fdev[2]*zprdinit;
+          if (pstyle == TRICLINIC) {
+            if (p_flag[3]) fextra[3] -= fdev[3]*yprdinit;
+            if (p_flag[4]) fextra[4] -= fdev[4]*xprdinit;
+            if (p_flag[5]) fextra[5] -= fdev[5]*xprdinit;
+          }
+
+          eng += compute_strain_energy();
+        }
+      }
+      return eng;
     }
-  }
 
-  return eng;
-}
+    /* ----------------------------------------------------------------------
+       store extra dof values for minimization linesearch starting point
+       boxlo0,boxhi0 = box dimensions
+       box values are pushed onto a LIFO stack so nested calls can be made
+       values are popped by calling min_step(0.0)
+    ------------------------------------------------------------------------- */
 
-/* ----------------------------------------------------------------------
-   store extra dof values for minimization linesearch starting point
-   boxlo0,boxhi0 = box dimensions
-   box values are pushed onto a LIFO stack so nested calls can be made
-   values are popped by calling min_step(0.0)
-------------------------------------------------------------------------- */
-
-void FixCACBoxRelax::min_store()
-{
-  for (int i = 0; i < 3; i++) {
-    boxlo0[current_lifo][i] = domain->boxlo[i];
-    boxhi0[current_lifo][i] = domain->boxhi[i];
-  }
-  if (pstyle == TRICLINIC) {
-    boxtilt0[current_lifo][0] = domain->yz;
-    boxtilt0[current_lifo][1] = domain->xz;
-    boxtilt0[current_lifo][2] = domain->xy;
-  }
-}
-
-/* ----------------------------------------------------------------------
-   clear the LIFO stack for min_store
-------------------------------------------------------------------------- */
-
-void FixCACBoxRelax::min_clearstore()
-{
-  current_lifo = 0;
-}
-
-/* ----------------------------------------------------------------------
-   push the LIFO stack for min_store
-------------------------------------------------------------------------- */
-
-void FixCACBoxRelax::min_pushstore()
-{
-  if (current_lifo >= MAX_LIFO_DEPTH) {
-    error->all(FLERR,"Attempt to push beyond stack limit in fix cac/box/relax");
-    return;
-  }
-  current_lifo++;
-}
-
-
-/* ----------------------------------------------------------------------
-   pop the LIFO stack for min_store
-------------------------------------------------------------------------- */
-
-void FixCACBoxRelax::min_popstore()
-{
-  if (current_lifo <= 0) {
-    error->all(FLERR,"Attempt to pop empty stack in fix cac/box/relax");
-    return;
-  }
-  current_lifo--;
-}
-
-/* ----------------------------------------------------------------------
-   check if time to reset reference state. If so, do so.
-------------------------------------------------------------------------- */
-
-int FixCACBoxRelax::min_reset_ref()
-{
-  int itmp = 0;
-
-  // if nreset_h0 > 0, reset reference box
-  // every nreset_h0 timesteps
-  // only needed for deviatoric external stress
-
-  if (deviatoric_flag && nreset_h0 > 0) {
-    int delta = update->ntimestep - update->beginstep;
-    if (delta % nreset_h0 == 0) {
-      compute_sigma();
-      itmp = 1;
+    void FixCACBoxRelax::min_store()
+    {
+      for (int i = 0; i < 3; i++) {
+        boxlo0[current_lifo][i] = domain->boxlo[i];
+        boxhi0[current_lifo][i] = domain->boxhi[i];
+      }
+      if (pstyle == TRICLINIC) {
+        boxtilt0[current_lifo][0] = domain->yz;
+        boxtilt0[current_lifo][1] = domain->xz;
+        boxtilt0[current_lifo][2] = domain->xy;
+      }
     }
-  }
-  return itmp;
-}
 
-/* ----------------------------------------------------------------------
-   change the box dimensions by fraction ds = alpha*hextra
-------------------------------------------------------------------------- */
+    /* ----------------------------------------------------------------------
+       clear the LIFO stack for min_store
+    ------------------------------------------------------------------------- */
 
-void FixCACBoxRelax::min_step(double alpha, double *hextra)
-{
-  if (pstyle == ISO) {
-    ds[0] = ds[1] = ds[2] = alpha*hextra[0];
-  } else {
-    ds[0] = ds[1] = ds[2] = 0.0;
-    if (p_flag[0]) ds[0] = alpha*hextra[0];
-    if (p_flag[1]) ds[1] = alpha*hextra[1];
-    if (p_flag[2]) ds[2] = alpha*hextra[2];
-    if (pstyle == TRICLINIC) {
+    void FixCACBoxRelax::min_clearstore()
+    {
+      current_lifo = 0;
+    }
+
+    /* ----------------------------------------------------------------------
+       push the LIFO stack for min_store
+    ------------------------------------------------------------------------- */
+
+    void FixCACBoxRelax::min_pushstore()
+    {
+      if (current_lifo >= MAX_LIFO_DEPTH) {
+        error->all(FLERR,"Attempt to push beyond stack limit in fix cac/box/relax");
+        return;
+      }
+      current_lifo++;
+    }
+
+
+    /* ----------------------------------------------------------------------
+       pop the LIFO stack for min_store
+    ------------------------------------------------------------------------- */
+
+    void FixCACBoxRelax::min_popstore()
+    {
+      if (current_lifo <= 0) {
+        error->all(FLERR,"Attempt to pop empty stack in fix cac/box/relax");
+        return;
+      }
+      current_lifo--;
+    }
+
+    /* ----------------------------------------------------------------------
+       check if time to reset reference state. If so, do so.
+    ------------------------------------------------------------------------- */
+
+    int FixCACBoxRelax::min_reset_ref()
+    {
+      int itmp = 0;
+
+      // if nreset_h0 > 0, reset reference box
+      // every nreset_h0 timesteps
+      // only needed for deviatoric external stress
+
+      if (deviatoric_flag && nreset_h0 > 0) {
+        int delta = update->ntimestep - update->beginstep;
+        if (delta % nreset_h0 == 0) {
+          compute_sigma();
+          itmp = 1;
+        }
+      }
+      return itmp;
+    }
+
+    /* ----------------------------------------------------------------------
+       change the box dimensions by fraction ds = alpha*hextra
+    ------------------------------------------------------------------------- */
+
+    void FixCACBoxRelax::min_step(double alpha, double *hextra)
+    {
+      if (pstyle == ISO) {
+        ds[0] = ds[1] = ds[2] = alpha*hextra[0];
+      } else {
+        ds[0] = ds[1] = ds[2] = 0.0;
+        if (p_flag[0]) ds[0] = alpha*hextra[0];
+        if (p_flag[1]) ds[1] = alpha*hextra[1];
+        if (p_flag[2]) ds[2] = alpha*hextra[2];
+        if (pstyle == TRICLINIC) {
       ds[3] = ds[4] = ds[5] = 0.0;
       if (p_flag[3]) ds[3] = alpha*hextra[3];
       if (p_flag[4]) ds[4] = alpha*hextra[4];
@@ -650,19 +651,25 @@ void FixCACBoxRelax::remap()
   // scale atom coords for all atoms or only for fix group atoms
 
   double ****nodal_positions = atom->nodal_positions; 
+  double *x;
+  double *min_x = atom->min_x;
   int *npoly = atom->poly_count;
   int *nodes_per_element_list = atom->nodes_per_element_list;
   int *element_type = atom->element_type;
   int *mask = atom->mask;
+  int dense_count_x=0;
   n = atom->nlocal + atom->nghost;
 
   // convert pertinent atoms and rigid bodies to lamda coords
 
   for (i = 0; i < n; i++){
-    for(int ip=0; ip < npoly[i]; ip++){
-      for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
-        if (mask[i] & groupbit)
-          domain->x2lamda(nodal_positions[i][ip][in],nodal_positions[i][ip][in]);
+    if (mask[i] & groupbit){
+      for(int ip=0; ip < npoly[i]; ip++){
+        for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+            x = &min_x[dense_count_x];
+            domain->x2lamda(x,x);
+            dense_count_x+=3;
+        }
       }
     }
   }
@@ -700,15 +707,18 @@ void FixCACBoxRelax::remap()
 
   // convert pertinent atoms and rigid bodies back to box coords
 
+  dense_count_x=0;
   for (i = 0; i < n; i++){
-    for(int ip=0; ip < npoly[i]; ip++){
-      for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
-        if (mask[i] & groupbit)
-          domain->lamda2x(nodal_positions[i][ip][in],nodal_positions[i][ip][in]);
+    if (mask[i] & groupbit){
+      for(int ip=0; ip < npoly[i]; ip++){
+        for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+            x = &min_x[dense_count_x];
+            domain->lamda2x(x,x);
+            dense_count_x+=3;
+        }
       }
     }
   }
-
   if (nrigid)
     for (i = 0; i < nrigid; i++)
       modify->fix[rfix[i]]->deform(1);
@@ -913,7 +923,6 @@ double FixCACBoxRelax::compute_strain_energy()
   }
 
   double energy = 0.5*(d0+d1+d2)*pv2e;
-  std::cout << energy << "\n";
   return energy;
 }
 

--- a/src/USER-CAC/fix_cac_box_relax.h
+++ b/src/USER-CAC/fix_cac_box_relax.h
@@ -1,0 +1,196 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(cac/box/relax,FixCACBoxRelax)
+
+#else
+
+#ifndef LMP_FIX_CAC_BOX_RELAX_H
+#define LMP_FIX_CAC_BOX_RELAX_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixCACBoxRelax : public Fix {
+ public:
+  FixCACBoxRelax(class LAMMPS *, int, char **);
+  ~FixCACBoxRelax();
+  int setmask();
+  void init();
+
+  double min_energy(double *);
+  void min_store();
+  void min_clearstore();
+  void min_pushstore();
+  void min_popstore();
+  int min_reset_ref();
+  void min_step(double, double *);
+  double max_alpha(double *);
+  int min_dof();
+
+  int modify_param(int, char **);
+
+ private:
+  int p_flag[6];
+  int pstyle,pcouple,allremap;
+  int dimension;
+  double p_target[6],p_current[6];
+  double vol0,xprdinit,yprdinit,zprdinit;
+  double vmax,pv2e,pflagsum;
+  int kspace_flag;
+
+  int current_lifo;              // LIFO stack pointer
+  double boxlo0[2][3];           // box bounds at start of line search
+  double boxhi0[2][3];
+  double boxtilt0[2][3];         // xy,xz,yz tilts at start of line search
+  double ds[6];                  // increment in scale matrix
+
+  int scaleyz;                   // 1 if yz scaled with lz
+  int scalexz;                   // 1 if xz scaled with lz
+  int scalexy;                   // 1 if xy scaled with ly
+
+  double fixedpoint[3];          // Location of dilation fixed-point
+
+  char *id_temp,*id_press;
+  class Compute *temperature,*pressure;
+  int tflag,pflag;
+
+  int nrigid;
+  int *rfix;
+
+  double sigma[6];                 // scaled target stress
+  double utsigma[3];               // weighting for upper-tri elements
+                                   // of modified sigma
+  int sigmamod_flag;               // 1 if modified sigma to be used
+  double fdev[6];                  // Deviatoric force on cell
+  int deviatoric_flag;             // 0 if target stress tensor is hydrostatic
+  double h0[6];                    // h_inv of reference (zero strain) box
+  double h0_inv[6];                // h_inv of reference (zero strain) box
+  int nreset_h0;                   // interval for resetting h0
+  double p_hydro;                  // hydrostatic component of target stress
+
+  void remap();
+  void couple();
+
+  void compute_sigma();
+  void compute_deviatoric();
+  double compute_strain_energy();
+  void compute_press_target();
+  double compute_scalar();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Invalid fix box/relax command for a 2d simulation
+
+Fix box/relax styles involving the z dimension cannot be used in
+a 2d simulation.
+
+E: Invalid fix box/relax command pressure settings
+
+If multiple dimensions are coupled, those dimensions must be specified.
+
+E: Cannot use fix box/relax on a non-periodic dimension
+
+When specifying a diagonal pressure component, the dimension must be
+periodic.
+
+E: Cannot use fix box/relax on a 2nd non-periodic dimension
+
+When specifying an off-diagonal pressure component, the 2nd of the two
+dimensions must be periodic.  E.g. if the xy component is specified,
+then the y dimension must be periodic.
+
+E: Cannot use fix box/relax with tilt factor scaling on a 2nd non-periodic dimension
+
+When specifying scaling on a tilt factor component, the 2nd of the two
+dimensions must be periodic.  E.g. if the xy component is specified,
+then the y dimension must be periodic.
+
+E: Cannot use fix box/relax with both relaxation and scaling on a tilt factor
+
+When specifying scaling on a tilt factor component, that component can not
+also be controlled by the barostat. E.g. if scalexy yes is specified and
+also keyword tri or xy, this is wrong.
+
+E: Can not specify Pxy/Pxz/Pyz in fix box/relax with non-triclinic box
+
+Only triclinic boxes can be used with off-diagonal pressure components.
+See the region prism command for details.
+
+E: Invalid fix box/relax pressure settings
+
+Settings for coupled dimensions must be the same.
+
+E: Temperature ID for fix box/relax does not exist
+
+Self-explanatory.
+
+E: Pressure ID for fix box/relax does not exist
+
+The compute ID needed to compute pressure for the fix does not
+exist.
+
+E: Attempt to push beyond stack limit in fix box/relax
+
+Internal LAMMPS error.  Please report it to the developers.
+
+E: Attempt to pop empty stack in fix box/relax
+
+Internal LAMMPS error.  Please report it to the developers.
+
+E: Fix box/relax generated negative box length
+
+The pressure being applied is likely too large.  Try applying
+it incrementally, to build to the high pressure.
+
+E: Could not find fix_modify temperature ID
+
+The compute ID for computing temperature does not exist.
+
+E: Fix_modify temperature ID does not compute temperature
+
+The compute ID assigned to the fix must compute temperature.
+
+W: Temperature for fix modify is not for group all
+
+The temperature compute is being used with a pressure calculation
+which does operate on group all, so this may be inconsistent.
+
+E: Pressure ID for fix modify does not exist
+
+Self-explanatory.
+
+E: Could not find fix_modify pressure ID
+
+The compute ID for computing pressure does not exist.
+
+E: Fix_modify pressure ID does not compute pressure
+
+The compute ID assigned to the fix must compute pressure.
+
+*/

--- a/src/USER-CAC/pair_cac.cpp
+++ b/src/USER-CAC/pair_cac.cpp
@@ -114,15 +114,17 @@ PairCAC::~PairCAC() {
 
 void PairCAC::compute(int eflag, int vflag) {
   int i;
-  double delx,dely,delz,fpair;
+  double delx,dely,delz,fpair, v[6];
   int mi;
   int mj;
   int singular;
   ev_init(eflag,vflag);
+  v[0]=0;v[1]=0;v[2]=0;v[3]=0;v[4]=0;v[5]=0;
 
   double **x = atom->x;
   double ****nodal_positions= atom->nodal_positions;
   double ****nodal_forces= atom->nodal_forces;
+  double ****nodal_virial= atom->nodal_virial;
   int *element_type = atom->element_type;
   int *poly_count = atom->poly_count;
   int **node_types = atom->node_types;
@@ -212,8 +214,23 @@ void PairCAC::compute(int eflag, int vflag) {
         }
       }
     }
+    //Tally energy
     if (evflag) ev_tally_full(i,
           2 * element_energy, 0.0, fpair, delx, dely, delz);
+
+    //Tally virial, this requires looping over all nodes and atoms
+    if(vflag){
+      for (poly_counter = 0; poly_counter < current_poly_count; poly_counter++) {
+            for (mi = 0; mi < nodes_per_element; mi++){
+                for( int dim = 0; dim < 6; dim ++) v[dim] = nodal_virial[i][poly_counter][mi][dim];
+                // For elements we have to multiply by the number of atoms assigned to node. Just assume that all the elements are rhombohedral for right now
+                if(element_scale[i][0] > 1){
+                    for(int dim = 0; dim < 6; dim ++) v[dim] *= (element_scale[i][0]*element_scale[i][1]*element_scale[i][2])/8.0;
+                }
+                v_tally_tensor(0,0,1,0,v[0],v[1],v[2],v[3],v[4],v[5]);
+            }
+      }
+    }
   }
 }
 
@@ -262,25 +279,26 @@ void PairCAC::init_style()
   // create fix needed for storing nodal flux vector if needed
   // deleted at the end of run by modify
   if(atom->cac_flux_flag){
-  char **fixarg = new char*[4];
-  fixarg[0] = (char *) "CACNODALFLUX";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "CAC/ALLOCVECTOR";
-  fixarg[3] = (char *) "3";
-  modify->add_fix(4,fixarg);
-  
-  
-  fix_cac_alloc_vector = (FixCACAllocVector *) modify->fix[modify->nfix-1];
+    char **fixarg = new char*[4];
+    fixarg[0] = (char *) "CACNODALFLUX";
+    fixarg[1] = (char *) "all";
+    fixarg[2] = (char *) "CAC/ALLOCVECTOR";
+    fixarg[3] = (char *) "3";
+    modify->add_fix(4,fixarg);
+    
+    
+    fix_cac_alloc_vector = (FixCACAllocVector *) modify->fix[modify->nfix-1];
 
-  fix_cac_alloc_vector->add_vector(24);
-  atom->nodal_fluxes = fix_cac_alloc_vector->request_vector(0);
+    fix_cac_alloc_vector->add_vector(24);
+    atom->nodal_fluxes = fix_cac_alloc_vector->request_vector(0);
 
-  fixarg[0] = (char *) "CACFLUXCHECK";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "CAC/FLUXCHECK";
-  modify->add_fix(3,fixarg);
-  delete [] fixarg;
+    fixarg[0] = (char *) "CACFLUXCHECK";
+    fixarg[1] = (char *) "all";
+    fixarg[2] = (char *) "CAC/FLUXCHECK";
+    modify->add_fix(3,fixarg);
+    delete [] fixarg;
   }
+
   
 }
 
@@ -436,12 +454,13 @@ void PairCAC::compute_forcev(int iii){
     force_density[1] = 0;
     force_density[2] = 0;
     if(atom->CAC_virial){
-    virial_density[0] = 0;
-    virial_density[1] = 0;
-    virial_density[2] = 0;
-    virial_density[3] = 0;
-    virial_density[4] = 0;
-    virial_density[5] = 0;
+      virial_density[0] = 0;
+      virial_density[1] = 0;
+      virial_density[2] = 0;
+      virial_density[3] = 0;
+      virial_density[4] = 0;
+      virial_density[5] = 0;
+      
     }
     if(quad_flux_flag)
       for(int init = 0; init < 24; init++)
@@ -468,8 +487,9 @@ void PairCAC::compute_forcev(int iii){
       force_column[js][jj] += coefficients*force_density[jj] * shape_func;
     }
     if(atom->CAC_virial){
-    for (int jj = 0; jj < 6; jj++)
-      nodal_virial[iii][poly_counter][js][jj] += coefficients*virial_density[jj] * shape_func;
+      for (int jj = 0; jj < 6; jj++){
+          nodal_virial[iii][poly_counter][js][jj] += coefficients*virial_density[jj] * shape_func;
+        }
     }
     if(quad_flux_flag&&atom->cac_flux_flag==2){
     for (int jj = 0; jj < 24; jj++)

--- a/src/fix_box_relax.cpp
+++ b/src/fix_box_relax.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstring>
 #include <string>
+#include <iostream>
 #include "atom.h"
 #include "domain.h"
 #include "update.h"
@@ -905,6 +906,7 @@ double FixBoxRelax::compute_strain_energy()
   }
 
   double energy = 0.5*(d0+d1+d2)*pv2e;
+  std::cout << energy << "\n";
   return energy;
 }
 


### PR DESCRIPTION
**Summary**

Adds compute pressure and cac/box/relax to lammps code.

**Related Issues**
None
**Author(s)**

Alex Selimov, Georgia Tech
**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
Nothing seems to break 

**Implementation Notes**
Change default thermo compute from compute temp to compute cac/nodal/temp. Add correct summation of virial. Added fix_cac_box_relax files with implementation,

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


