### PR TITLE
Removing useless line in fix_cac_box_relax.cpp and adding fix_cac_pre…

### DIFF
--- a/src/USER-CAC/fix_cac_box_relax.cpp
+++ b/src/USER-CAC/fix_cac_box_relax.cpp
@@ -427,6 +427,9 @@ void FixCACBoxRelax::init()
 
   compute_press_target();
   if (deviatoric_flag) compute_sigma();
+
+  //Set virial flag
+  atom->CAC_virial=1;
 }
 
 /* ----------------------------------------------------------------------
@@ -650,7 +653,6 @@ void FixCACBoxRelax::remap()
   // rescale simulation box from linesearch starting point
   // scale atom coords for all atoms or only for fix group atoms
 
-  double ****nodal_positions = atom->nodal_positions; 
   double *x;
   double *min_x = atom->min_x;
   int *npoly = atom->poly_count;

--- a/src/USER-CAC/fix_cac_press_berendsen.cpp
+++ b/src/USER-CAC/fix_cac_press_berendsen.cpp
@@ -1,0 +1,525 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_cac_press_berendsen.h"
+#include <cstring>
+#include <cmath>
+#include <string>
+#include "atom.h"
+#include "force.h"
+#include "comm.h"
+#include "modify.h"
+#include "fix_deform.h"
+#include "compute.h"
+#include "kspace.h"
+#include "update.h"
+#include "domain.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+enum{NOBIAS,BIAS};
+enum{NONE,XYZ,XY,YZ,XZ};
+enum{ISO,ANISO};
+
+/* ---------------------------------------------------------------------- */
+
+FixCACPressBerendsen::FixCACPressBerendsen(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg),
+  id_temp(NULL), id_press(NULL), tflag(0), pflag(0)
+{
+  if (narg < 5) error->all(FLERR,"Illegal fix press/berendsen command");
+
+  // Berendsen barostat applied every step
+
+  nevery = 1;
+
+  // default values
+
+  pcouple = NONE;
+  bulkmodulus = 10.0;
+  allremap = 1;
+
+  for (int i = 0; i < 3; i++) {
+    p_start[i] = p_stop[i] = p_period[i] = 0.0;
+    p_flag[i] = 0;
+    p_period[i] = 0.0;
+  }
+
+  // process keywords
+
+  dimension = domain->dimension;
+
+  int iarg = 3;
+
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"iso") == 0) {
+      if (iarg+4 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      pcouple = XYZ;
+      p_start[0] = p_start[1] = p_start[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_stop[0] = p_stop[1] = p_stop[2] = force->numeric(FLERR,arg[iarg+2]);
+      p_period[0] = p_period[1] = p_period[2] = force->numeric(FLERR,arg[iarg+3]);
+      p_flag[0] = p_flag[1] = p_flag[2] = 1;
+      if (dimension == 2) {
+        p_start[2] = p_stop[2] = p_period[2] = 0.0;
+        p_flag[2] = 0;
+      }
+      iarg += 4;
+    } else if (strcmp(arg[iarg],"aniso") == 0) {
+      if (iarg+4 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      pcouple = NONE;
+      p_start[0] = p_start[1] = p_start[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_stop[0] = p_stop[1] = p_stop[2] = force->numeric(FLERR,arg[iarg+2]);
+      p_period[0] = p_period[1] = p_period[2] = force->numeric(FLERR,arg[iarg+3]);
+      p_flag[0] = p_flag[1] = p_flag[2] = 1;
+      if (dimension == 2) {
+        p_start[2] = p_stop[2] = p_period[2] = 0.0;
+        p_flag[2] = 0;
+      }
+      iarg += 4;
+
+    } else if (strcmp(arg[iarg],"x") == 0) {
+      if (iarg+4 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      p_start[0] = force->numeric(FLERR,arg[iarg+1]);
+      p_stop[0] = force->numeric(FLERR,arg[iarg+2]);
+      p_period[0] = force->numeric(FLERR,arg[iarg+3]);
+      p_flag[0] = 1;
+      iarg += 4;
+    } else if (strcmp(arg[iarg],"y") == 0) {
+      if (iarg+4 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      p_start[1] = force->numeric(FLERR,arg[iarg+1]);
+      p_stop[1] = force->numeric(FLERR,arg[iarg+2]);
+      p_period[1] = force->numeric(FLERR,arg[iarg+3]);
+      p_flag[1] = 1;
+      iarg += 4;
+    } else if (strcmp(arg[iarg],"z") == 0) {
+      if (iarg+4 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      p_start[2] = force->numeric(FLERR,arg[iarg+1]);
+      p_stop[2] = force->numeric(FLERR,arg[iarg+2]);
+      p_period[2] = force->numeric(FLERR,arg[iarg+3]);
+      p_flag[2] = 1;
+      iarg += 4;
+      if (dimension == 2)
+        error->all(FLERR,"Invalid fix press/berendsen for a 2d simulation");
+
+    } else if (strcmp(arg[iarg],"couple") == 0) {
+      if (iarg+2 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      if (strcmp(arg[iarg+1],"xyz") == 0) pcouple = XYZ;
+      else if (strcmp(arg[iarg+1],"xy") == 0) pcouple = XY;
+      else if (strcmp(arg[iarg+1],"yz") == 0) pcouple = YZ;
+      else if (strcmp(arg[iarg+1],"xz") == 0) pcouple = XZ;
+      else if (strcmp(arg[iarg+1],"none") == 0) pcouple = NONE;
+      else error->all(FLERR,"Illegal fix press/berendsen command");
+      iarg += 2;
+
+    } else if (strcmp(arg[iarg],"modulus") == 0) {
+      if (iarg+2 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      bulkmodulus = force->numeric(FLERR,arg[iarg+1]);
+      if (bulkmodulus <= 0.0)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"dilate") == 0) {
+      if (iarg+2 > narg)
+        error->all(FLERR,"Illegal fix press/berendsen command");
+      if (strcmp(arg[iarg+1],"all") == 0) allremap = 1;
+      else if (strcmp(arg[iarg+1],"partial") == 0) allremap = 0;
+      else error->all(FLERR,"Illegal fix press/berendsen command");
+      iarg += 2;
+    } else error->all(FLERR,"Illegal fix press/berendsen command");
+  }
+
+  if (allremap == 0) restart_pbc = 1;
+
+  // error checks
+
+  if (dimension == 2 && p_flag[2])
+    error->all(FLERR,"Invalid fix press/berendsen for a 2d simulation");
+  if (dimension == 2 && (pcouple == YZ || pcouple == XZ))
+    error->all(FLERR,"Invalid fix press/berendsen for a 2d simulation");
+
+  if (pcouple == XYZ && (p_flag[0] == 0 || p_flag[1] == 0))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XYZ && dimension == 3 && p_flag[2] == 0)
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XY && (p_flag[0] == 0 || p_flag[1] == 0))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == YZ && (p_flag[1] == 0 || p_flag[2] == 0))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XZ && (p_flag[0] == 0 || p_flag[2] == 0))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+
+  if (p_flag[0] && domain->xperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix press/berendsen on a non-periodic dimension");
+  if (p_flag[1] && domain->yperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix press/berendsen on a non-periodic dimension");
+  if (p_flag[2] && domain->zperiodic == 0)
+    error->all(FLERR,
+               "Cannot use fix press/berendsen on a non-periodic dimension");
+
+  if (pcouple == XYZ && dimension == 3 &&
+      (p_start[0] != p_start[1] || p_start[0] != p_start[2] ||
+       p_stop[0] != p_stop[1] || p_stop[0] != p_stop[2] ||
+       p_period[0] != p_period[1] || p_period[0] != p_period[2]))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XYZ && dimension == 2 &&
+      (p_start[0] != p_start[1] || p_stop[0] != p_stop[1] ||
+       p_period[0] != p_period[1]))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XY &&
+      (p_start[0] != p_start[1] || p_stop[0] != p_stop[1] ||
+       p_period[0] != p_period[1]))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == YZ &&
+      (p_start[1] != p_start[2] || p_stop[1] != p_stop[2] ||
+       p_period[1] != p_period[2]))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+  if (pcouple == XZ &&
+      (p_start[0] != p_start[2] || p_stop[0] != p_stop[2] ||
+       p_period[0] != p_period[2]))
+    error->all(FLERR,"Invalid fix press/berendsen pressure settings");
+
+  if ((p_flag[0] && p_period[0] <= 0.0) ||
+      (p_flag[1] && p_period[1] <= 0.0) ||
+      (p_flag[2] && p_period[2] <= 0.0))
+    error->all(FLERR,"Fix press/berendsen damping parameters must be > 0.0");
+
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+
+  // pstyle = ISO if XYZ coupling or XY coupling in 2d -> 1 dof
+  // else pstyle = ANISO -> 3 dof
+
+  if (pcouple == XYZ || (dimension == 2 && pcouple == XY)) pstyle = ISO;
+  else pstyle = ANISO;
+
+  // create a new compute temp style
+  // id = fix-ID + temp
+  // compute group = all since pressure is always global (group all)
+  //   and thus its KE/temperature contribution should use group all
+
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
+
+  tcmd += " all cac/nodal/temp";
+  modify->add_compute(tcmd);
+  tflag = 1;
+
+  // create a new compute pressure style
+  // id = fix-ID + press, compute group = all
+  // pass id_temp as 4th arg to pressure constructor
+
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
+
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
+  pflag = 1;
+
+  nrigid = 0;
+  rfix = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixCACPressBerendsen::~FixCACPressBerendsen()
+{
+  delete [] rfix;
+
+  // delete temperature and pressure if fix created them
+
+  if (tflag) modify->delete_compute(id_temp);
+  if (pflag) modify->delete_compute(id_press);
+  delete [] id_temp;
+  delete [] id_press;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixCACPressBerendsen::setmask()
+{
+  int mask = 0;
+  mask |= END_OF_STEP;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixCACPressBerendsen::init()
+{
+  if (domain->triclinic)
+    error->all(FLERR,"Cannot use fix press/berendsen with triclinic box");
+
+  // insure no conflict with fix deform
+
+  for (int i = 0; i < modify->nfix; i++)
+    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+      int *dimflag = ((FixDeform *) modify->fix[i])->dimflag;
+      if ((p_flag[0] && dimflag[0]) || (p_flag[1] && dimflag[1]) ||
+          (p_flag[2] && dimflag[2]))
+        error->all(FLERR,"Cannot use fix press/berendsen and "
+                   "fix deform on same component of stress tensor");
+    }
+
+  // set temperature and pressure ptrs
+
+  int icompute = modify->find_compute(id_temp);
+  if (icompute < 0)
+    error->all(FLERR,"Temperature ID for fix press/berendsen does not exist");
+  temperature = modify->compute[icompute];
+
+  if (temperature->tempbias) which = BIAS;
+  else which = NOBIAS;
+
+  icompute = modify->find_compute(id_press);
+  if (icompute < 0)
+    error->all(FLERR,"Pressure ID for fix press/berendsen does not exist");
+  pressure = modify->compute[icompute];
+
+  // Kspace setting
+
+  if (force->kspace) kspace_flag = 1;
+  else kspace_flag = 0;
+
+  // detect if any rigid fixes exist so rigid bodies move when box is remapped
+  // rfix[] = indices to each fix rigid
+
+  delete [] rfix;
+  nrigid = 0;
+  rfix = NULL;
+
+  for (int i = 0; i < modify->nfix; i++)
+    if (modify->fix[i]->rigid_flag) nrigid++;
+  if (nrigid) {
+    rfix = new int[nrigid];
+    nrigid = 0;
+    for (int i = 0; i < modify->nfix; i++)
+      if (modify->fix[i]->rigid_flag) rfix[nrigid++] = i;
+  }
+
+  //Set virial flag
+  atom->CAC_virial=1;
+}
+
+/* ----------------------------------------------------------------------
+   compute T,P before integrator starts
+------------------------------------------------------------------------- */
+
+void FixCACPressBerendsen::setup(int /*vflag*/)
+{
+  // trigger virial computation on next timestep
+
+  pressure->addstep(update->ntimestep+1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixCACPressBerendsen::end_of_step()
+{
+  // compute new T,P
+
+  if (pstyle == ISO) {
+    temperature->compute_scalar();
+    pressure->compute_scalar();
+  } else {
+    temperature->compute_vector();
+    pressure->compute_vector();
+  }
+  couple();
+
+  double delta = update->ntimestep - update->beginstep;
+  if (delta != 0.0) delta /= update->endstep - update->beginstep;
+
+  for (int i = 0; i < 3; i++) {
+    if (p_flag[i]) {
+      p_target[i] = p_start[i] + delta * (p_stop[i]-p_start[i]);
+      dilation[i] =
+        pow(1.0 - update->dt/p_period[i] *
+            (p_target[i]-p_current[i])/bulkmodulus,1.0/3.0);
+    }
+  }
+
+  // remap simulation box and atoms
+  // redo KSpace coeffs since volume has changed
+
+  remap();
+  if (kspace_flag) force->kspace->setup();
+
+  // trigger virial computation on next timestep
+
+  pressure->addstep(update->ntimestep+1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixCACPressBerendsen::couple()
+{
+  double *tensor = pressure->vector;
+
+  if (pstyle == ISO)
+    p_current[0] = p_current[1] = p_current[2] = pressure->scalar;
+  else if (pcouple == XYZ) {
+    double ave = 1.0/3.0 * (tensor[0] + tensor[1] + tensor[2]);
+    p_current[0] = p_current[1] = p_current[2] = ave;
+  } else if (pcouple == XY) {
+    double ave = 0.5 * (tensor[0] + tensor[1]);
+    p_current[0] = p_current[1] = ave;
+    p_current[2] = tensor[2];
+  } else if (pcouple == YZ) {
+    double ave = 0.5 * (tensor[1] + tensor[2]);
+    p_current[1] = p_current[2] = ave;
+    p_current[0] = tensor[0];
+  } else if (pcouple == XZ) {
+    double ave = 0.5 * (tensor[0] + tensor[2]);
+    p_current[0] = p_current[2] = ave;
+    p_current[1] = tensor[1];
+  } else {
+    p_current[0] = tensor[0];
+    p_current[1] = tensor[1];
+    p_current[2] = tensor[2];
+  }
+}
+
+/* ----------------------------------------------------------------------
+   change box size
+   remap all atoms or fix group atoms depending on allremap flag
+   if rigid bodies exist, scale rigid body centers-of-mass
+------------------------------------------------------------------------- */
+
+void FixCACPressBerendsen::remap()
+{
+  int i;
+  double oldlo,oldhi,ctr;
+
+  double *x;
+  double ****nodal_positions = atom->nodal_positions;
+  int *npoly = atom->poly_count;
+  int *nodes_per_element_list = atom->nodes_per_element_list;
+  int *element_type = atom->element_type;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+  // convert pertinent atoms and rigid bodies to lamda coords
+    for (i = 0; i < nlocal; i++){
+    if (mask[i] & groupbit){
+      for(int ip=0; ip < npoly[i]; ip++){
+        for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+            x = nodal_positions[i][ip][in];
+            domain->x2lamda(x,x);
+        }
+      }
+    }
+  }
+
+  if (nrigid)
+    for (i = 0; i < nrigid; i++)
+      modify->fix[rfix[i]]->deform(0);
+
+  // reset global and local box to new size/shape
+
+  for (i = 0; i < 3; i++) {
+    if (p_flag[i]) {
+      oldlo = domain->boxlo[i];
+      oldhi = domain->boxhi[i];
+      ctr = 0.5 * (oldlo + oldhi);
+      domain->boxlo[i] = (oldlo-ctr)*dilation[i] + ctr;
+      domain->boxhi[i] = (oldhi-ctr)*dilation[i] + ctr;
+    }
+  }
+
+  domain->set_global_box();
+  domain->set_local_box();
+
+  // convert pertinent atoms and rigid bodies back to box coords
+  for (i = 0; i < nlocal; i++){
+    if (mask[i] & groupbit){
+      for(int ip=0; ip < npoly[i]; ip++){
+        for(int in=0; in < nodes_per_element_list[element_type[i]]; in++){
+            x = nodal_positions[i][ip][in];
+            domain->lamda2x(x,x);
+        }
+      }
+    }
+  }
+
+  if (nrigid)
+    for (i = 0; i < nrigid; i++)
+      modify->fix[rfix[i]]->deform(1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixCACPressBerendsen::modify_param(int narg, char **arg)
+{
+  if (strcmp(arg[0],"temp") == 0) {
+    if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
+    if (tflag) {
+      modify->delete_compute(id_temp);
+      tflag = 0;
+    }
+    delete [] id_temp;
+    int n = strlen(arg[1]) + 1;
+    id_temp = new char[n];
+    strcpy(id_temp,arg[1]);
+
+    int icompute = modify->find_compute(arg[1]);
+    if (icompute < 0) error->all(FLERR,"Could not find fix_modify temperature ID");
+    temperature = modify->compute[icompute];
+
+    if (temperature->tempflag == 0)
+      error->all(FLERR,"Fix_modify temperature ID does not compute temperature");
+    if (temperature->igroup != 0 && comm->me == 0)
+      error->warning(FLERR,"Temperature for NPT is not for group all");
+
+    // reset id_temp of pressure to new temperature ID
+
+    icompute = modify->find_compute(id_press);
+    if (icompute < 0)
+      error->all(FLERR,"Pressure ID for fix press/berendsen does not exist");
+    modify->compute[icompute]->reset_extra_compute_fix(id_temp);
+
+    return 2;
+
+  } else if (strcmp(arg[0],"press") == 0) {
+    if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
+    if (pflag) {
+      modify->delete_compute(id_press);
+      pflag = 0;
+    }
+    delete [] id_press;
+    int n = strlen(arg[1]) + 1;
+    id_press = new char[n];
+    strcpy(id_press,arg[1]);
+
+    int icompute = modify->find_compute(arg[1]);
+    if (icompute < 0) error->all(FLERR,"Could not find fix_modify pressure ID");
+    pressure = modify->compute[icompute];
+
+    if (pressure->pressflag == 0)
+      error->all(FLERR,"Fix_modify pressure ID does not compute pressure");
+    return 2;
+  }
+  return 0;
+}

--- a/src/USER-CAC/fix_cac_press_berendsen.h
+++ b/src/USER-CAC/fix_cac_press_berendsen.h
@@ -1,0 +1,129 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(cac/press/berendsen,FixCACPressBerendsen)
+
+#else
+
+#ifndef LMP_FIX_CAC_PRESS_BERENDSEN_H
+#define LMP_FIX_CAC_PRESS_BERENDSEN_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixCACPressBerendsen : public Fix {
+ public:
+  FixCACPressBerendsen(class LAMMPS *, int, char **);
+  ~FixCACPressBerendsen();
+  int setmask();
+  void init();
+  void setup(int);
+  void end_of_step();
+  int modify_param(int, char **);
+
+ protected:
+  int dimension,which;
+  double bulkmodulus;
+
+  int pstyle,pcouple,allremap;
+  int p_flag[3];                   // 1 if control P on this dim, 0 if not
+  double p_start[3],p_stop[3];
+  double p_period[3],p_target[3];
+  double p_current[3],dilation[3];
+  double factor[3];
+  int kspace_flag;                 // 1 if KSpace invoked, 0 if not
+  int nrigid;                      // number of rigid fixes
+  int *rfix;                       // indices of rigid fixes
+
+  char *id_temp,*id_press;
+  class Compute *temperature,*pressure;
+  int tflag,pflag;
+
+  void couple();
+  void remap();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Invalid fix press/berendsen for a 2d simulation
+
+The z component of pressure cannot be controlled for a 2d model.
+
+E: Invalid fix press/berendsen pressure settings
+
+Settings for coupled dimensions must be the same.
+
+E: Cannot use fix press/berendsen on a non-periodic dimension
+
+Self-explanatory.
+
+E: Fix press/berendsen damping parameters must be > 0.0
+
+Self-explanatory.
+
+E: Cannot use fix press/berendsen with triclinic box
+
+Self-explanatory.
+
+E: Cannot use fix press/berendsen and fix deform on same component of stress tensor
+
+These commands both change the box size/shape, so you cannot use both
+together.
+
+E: Temperature ID for fix press/berendsen does not exist
+
+Self-explanatory.
+
+E: Pressure ID for fix press/berendsen does not exist
+
+The compute ID needed to compute pressure for the fix does not
+exist.
+
+E: Could not find fix_modify temperature ID
+
+The compute ID for computing temperature does not exist.
+
+E: Fix_modify temperature ID does not compute temperature
+
+The compute ID assigned to the fix must compute temperature.
+
+W: Temperature for NPT is not for group all
+
+User-assigned temperature to NPT fix does not compute temperature for
+all atoms.  Since NPT computes a global pressure, the kinetic energy
+contribution from the temperature is assumed to also be for all atoms.
+Thus the pressure used by NPT could be inaccurate.
+
+E: Could not find fix_modify pressure ID
+
+The compute ID for computing pressure does not exist.
+
+E: Fix_modify pressure ID does not compute pressure
+
+The compute ID assigned to the fix must compute pressure.
+
+*/


### PR DESCRIPTION
**Summary**

This adds fix cac/press/berendsen and fixes a problem with fix cac/box/relax where the virial flag wasn't getting set.

**Related Issues**

None

**Author(s)**

Alex Selimov alsel@tuta.io

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None

**Implementation Notes**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


